### PR TITLE
Loosen field requirements;Fix error handling

### DIFF
--- a/api/result.pb.go
+++ b/api/result.pb.go
@@ -19,8 +19,8 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type ExecResult struct {
-	Stdout  []byte `protobuf:"bytes,1,req,name=stdout" json:"stdout,omitempty"`
-	Stderr  []byte `protobuf:"bytes,2,req,name=stderr" json:"stderr,omitempty"`
+	Stdout  []byte `protobuf:"bytes,1,opt,name=stdout" json:"stdout,omitempty"`
+	Stderr  []byte `protobuf:"bytes,2,opt,name=stderr" json:"stderr,omitempty"`
 	Success *bool  `protobuf:"varint,3,req,name=success" json:"success,omitempty"`
 	Elapsed *int64 `protobuf:"varint,4,req,name=elapsed" json:"elapsed,omitempty"`
 }
@@ -76,17 +76,13 @@ func (m *ExecResult) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.Stdout == nil {
-		return 0, new(github_com_golang_protobuf_proto.RequiredNotSetError)
-	} else {
+	if m.Stdout != nil {
 		data[i] = 0xa
 		i++
 		i = encodeVarintResult(data, i, uint64(len(m.Stdout)))
 		i += copy(data[i:], m.Stdout)
 	}
-	if m.Stderr == nil {
-		return 0, new(github_com_golang_protobuf_proto.RequiredNotSetError)
-	} else {
+	if m.Stderr != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintResult(data, i, uint64(len(m.Stderr)))
@@ -235,7 +231,6 @@ func (m *ExecResult) Unmarshal(data []byte) error {
 				m.Stdout = []byte{}
 			}
 			iNdEx = postIndex
-			hasFields[0] |= uint64(0x00000001)
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Stderr", wireType)
@@ -267,7 +262,6 @@ func (m *ExecResult) Unmarshal(data []byte) error {
 				m.Stderr = []byte{}
 			}
 			iNdEx = postIndex
-			hasFields[0] |= uint64(0x00000002)
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Success", wireType)
@@ -289,7 +283,7 @@ func (m *ExecResult) Unmarshal(data []byte) error {
 			}
 			b := bool(v != 0)
 			m.Success = &b
-			hasFields[0] |= uint64(0x00000004)
+			hasFields[0] |= uint64(0x00000001)
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Elapsed", wireType)
@@ -310,7 +304,7 @@ func (m *ExecResult) Unmarshal(data []byte) error {
 				}
 			}
 			m.Elapsed = &v
-			hasFields[0] |= uint64(0x00000008)
+			hasFields[0] |= uint64(0x00000002)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipResult(data[iNdEx:])
@@ -330,12 +324,6 @@ func (m *ExecResult) Unmarshal(data []byte) error {
 		return new(github_com_golang_protobuf_proto.RequiredNotSetError)
 	}
 	if hasFields[0]&uint64(0x00000002) == 0 {
-		return new(github_com_golang_protobuf_proto.RequiredNotSetError)
-	}
-	if hasFields[0]&uint64(0x00000004) == 0 {
-		return new(github_com_golang_protobuf_proto.RequiredNotSetError)
-	}
-	if hasFields[0]&uint64(0x00000008) == 0 {
 		return new(github_com_golang_protobuf_proto.RequiredNotSetError)
 	}
 
@@ -456,10 +444,10 @@ var fileDescriptorResult = []byte{
 	0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0xcf, 0x4f, 0xcf, 0xd7, 0x07,
 	0xcb, 0x25, 0x95, 0xa6, 0x81, 0x79, 0x60, 0x0e, 0x98, 0x05, 0xd1, 0xa3, 0x14, 0xc2, 0xc5, 0xe5,
 	0x5a, 0x91, 0x9a, 0x1c, 0x04, 0x36, 0x47, 0x88, 0x8f, 0x8b, 0xad, 0xb8, 0x24, 0x25, 0xbf, 0xb4,
-	0x44, 0x82, 0x51, 0x81, 0x49, 0x83, 0x07, 0xca, 0x4f, 0x2d, 0x2a, 0x92, 0x60, 0x02, 0xf3, 0xf9,
+	0x44, 0x82, 0x51, 0x81, 0x51, 0x83, 0x07, 0xca, 0x4f, 0x2d, 0x2a, 0x92, 0x60, 0x02, 0xf3, 0xf9,
 	0xb9, 0xd8, 0x8b, 0x4b, 0x93, 0x93, 0x53, 0x8b, 0x8b, 0x25, 0x98, 0x15, 0x98, 0x34, 0x38, 0x40,
 	0x02, 0xa9, 0x39, 0x89, 0x05, 0xc5, 0xa9, 0x29, 0x12, 0x2c, 0x0a, 0x4c, 0x1a, 0xcc, 0x56, 0x2c,
 	0x17, 0x16, 0xca, 0x33, 0x38, 0x09, 0x9c, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83,
-	0x47, 0x72, 0x8c, 0x33, 0x1e, 0xcb, 0x31, 0x00, 0x02, 0x00, 0x00, 0xff, 0xff, 0x8c, 0xf6, 0x52,
-	0x9a, 0xaa, 0x00, 0x00, 0x00,
+	0x47, 0x72, 0x8c, 0x33, 0x1e, 0xcb, 0x31, 0x00, 0x02, 0x00, 0x00, 0xff, 0xff, 0xa2, 0xc6, 0x45,
+	0x85, 0xaa, 0x00, 0x00, 0x00,
 }

--- a/api/result.proto
+++ b/api/result.proto
@@ -10,8 +10,8 @@ option (gogoproto.unmarshaler_all) = true;
 
 message ExecResult {
   option (gogoproto.goproto_unrecognized) = false;
-  required bytes stdout = 1;
-  required bytes stderr = 2;
+  optional bytes stdout = 1;
+  optional bytes stderr = 2;
   required bool success = 3;
   required int64 elapsed = 4;
 }


### PR DESCRIPTION
Requiring both stdout and stderr caused api.Result serialization to fail
when both streams were empty. This condition was triggered when a
command invocation resulted in an error due to Relay's mis-handling of
errors returned from golang's `os/exec.Process.Run()`. Triggering this
bug caused an encoding error (see circuit-driver/main.go:28-31) which
subsequently caused the driver and container to exit.

From the user's PoV this error would present in two ways:
1. No error message when one should be displayed such as when
   `config.yaml` points to the wrong path for a command executable.
2. Truncated, missing, or empty output when output is expected. I think
   the most common occurrance would be missing log output.

This commit loosens field requirements on api.Result and also fixes
Relay's bad error handling logic.

Fixes [#836](https://github.com/operable/cog/issues/836)
